### PR TITLE
Add logging and audio configuration for OpenAI responses

### DIFF
--- a/server.js
+++ b/server.js
@@ -56,7 +56,7 @@ app.ws("/media", (ws) => {
         instructions: "You are Rachel, a friendly HVAC receptionist. Greet callers warmly, ask about their HVAC issue, and respond conversationally with audio.",
         modalities: ["audio"],
         conversation: "default",
-        audio: { voice: "verse" }
+        audio: { voice: "verse", format: "wav" }
       }
     }));
   });
@@ -79,8 +79,10 @@ app.ws("/media", (ws) => {
 
   // Forward AI audio → caller
   openai.on("message", (event) => {
+    const eventString = event.toString();
+    console.log("OpenAI msg:", eventString.slice(0, 200));
     try {
-      const response = JSON.parse(event.toString());
+      const response = JSON.parse(eventString);
       if (response.type === "output_audio_buffer.append" && response.audio) {
         ws.send(JSON.stringify({
           event: "media",


### PR DESCRIPTION
## Summary
- log the first part of each OpenAI realtime message for easier debugging
- request audio output from OpenAI using the verse wav configuration so replies contain audio

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d189f29ce4832f819e6536289fc48a